### PR TITLE
Scrum Roles aangemaakt met eerste informatie

### DIFF
--- a/content/10. SCRUM/3. Uitleg Scrum Roles.md
+++ b/content/10. SCRUM/3. Uitleg Scrum Roles.md
@@ -1,0 +1,32 @@
+---
+title: 3. Uitleg Scrum Roles
+taxonomie:
+---
+
+
+## Wat zijn Scrum Roles?
+Scrum Roles zijn de drie hoofdrollen binnen het Scrum-raamwerk, een populaire agile ontwikkelmethode. Deze rollen zorgen ervoor dat een Scrum-team effectief kan samenwerken, feedback cyclisch kan verwerken en producten iteratief kan opleveren. De rollen zijn strikt gescheiden om verwarring over verantwoordelijkheden te voorkomen. De drie standaardrollen in Scrum zijn:
+* **Product Owner**
+* **Scrum Master**
+* **Development Team**
+
+Elke rol heeft een unieke verantwoordelijkheid. Samen vormen zij een multidisciplinair team dat continu waarde levert aan de klant.
+
+> [!TIP] Casus
+> Stel je voor: een team werkt aan een mobiele app voor een gezondheidszorginstelling. Zonder duidelijke Scrum Roles ontstaat verwarring: wie bepaalt welke functies prioriteit hebben? Wie bewaakt het proces? Dankzij het toepassen van Scrum Roles wordt het duidelijk: de Product Owner bepaalt de prioriteiten, de Scrum Master faciliteert het proces, en het development team ontwikkelt de app.
+
+## Hoe zitten Scrum Roles in elkaar?
+De structuur van Scrum Roles is gebaseerd op duidelijke verantwoordelijkheden en samenwerking binnen het Scrum Team:
+* **Product Owner (PO):**
+De PO vertegenwoordigt de klant of stakeholders. Hij/zij beheert de Product Backlog, stelt prioriteiten op basis van waarde en zorgt ervoor dat het team werkt aan wat het meest waardevol is.
+* **Scrum Master:**
+De Scrum Master is de procesbewaker. Hij/zij zorgt ervoor dat Scrum correct wordt toegepast, begeleidt het team in agile principes, verwijdert obstakels en faciliteert de dagelijkse stand-ups, sprint planning en retrospectives.
+* **Development Team:**
+Dit is een zelfsturend, crossfunctioneel team dat het werk uitvoert. Ze zijn verantwoordelijk voor het leveren van een werkend product aan het einde van iedere sprint.
+
+## Hoe gebruik je Scrum Roles?
+Scrum Roles worden toegepast binnen agile ontwikkeltrajecten om rollen en verantwoordelijkheden helder te definiëren. Je gebruikt ze wanneer je werkt in iteraties (sprints), klantfeedback wilt integreren, en waarde wilt leveren met korte oplevercycli.
+
+> [!TIP] Casus
+>In een project voor een educatieve start-up wordt een leerplatform ontwikkeld. Het team heeft eerder zonder vaste structuur gewerkt en liep vast door miscommunicatie. Nu willen ze Scrum gebruiken.
+


### PR DESCRIPTION
## Beschrijving
OI voor Scrum Roles. Misschien de onderstaande casus weghalen? Ik heb hem ook maar gelabeld als 3. Uitleg Scrum Roles, misschien in een aparte folder plaatsen? In mijn lijstje staat hij anders als derde:
* Framework
* Pillars
* **Roles**
* ..

## Checklist
- [ ] Content voldoet aan gestelde eisen uit `Kwaliteitseisen Onderwijs Aanbod.docx`
- [ ] Spellingscheck gedaan
- [ ] Content geschreven volgens de gekoppelde 4C/ID componenten templates
- [ ] De naam van het onderwerp in de tekst is bold
- [ ] MD koppen hebben geen bold teksten
- [ ] Juiste format voor image/figuur naamgevingen
- [ ] Figuur onderschriften toegevoegd waar nodig
- [ ] Taxonomie codes toegevoegd
- [ ] Witregels gecheckt
- [ ] Bronnenlijst toegevoegd (indien nodig)
- [ ] Content-branch gepulled in de feature branch
- [ ] Benodigde verwijzingen toegevoegd
