### PR TITLE
Correctie Oefeningen List.md opdracht 2

### DIFF
--- a/build/4. Csharp/Datastructuren/List/2. Oefeningen List.md
+++ b/build/4. Csharp/Datastructuren/List/2. Oefeningen List.md
@@ -62,7 +62,7 @@ using System;
 
 List<int> numbers = new ________;
 
-foreach (string number in numbers)
+foreach (int number in numbers)
 {
     Console.WriteLine(number);
 }
@@ -74,7 +74,7 @@ foreach (string number in numbers)
 >
 > List<int> numbers = new List<int>(){1,2,3,4,5,6};
 >
-> foreach (string number in numbers)
+> foreach (int number in numbers)
 > {
 >    Console.WriteLine(number);
 > }
@@ -403,4 +403,5 @@ Console.WriteLine($"ItemCount is: {itemcount}");
 > int itemcount = groceries.Count;
 > 
 > Console.WriteLine($"ItemCount is: {itemcount}");
+
 > ```


### PR DESCRIPTION
## Beschrijving
Er wordt in deze opdracht gedaan alsof je in een foreach een string mee kunt geven als de lijst alleen ints bevat:
 
List<int> numbers = new ________;
foreach (string number in numbers)
{
    Console.WriteLine(number);
}
 
In bovenstaande is 'string' gewijzigd in 'int'.

## Checklist
- [x] Content voldoet aan gestelde eisen uit `Kwaliteitseisen Onderwijs Aanbod.docx`
- [x] Spellingscheck gedaan
- [x] Content geschreven volgens de gekoppelde 4C/ID componenten templates
- [x] De naam van het onderwerp in de tekst is bold
- [x] MD koppen hebben geen bold teksten
- [x] Juiste format voor image/figuur naamgevingen
- [x] Figuur onderschriften toegevoegd waar nodig
- [x] Taxonomie codes toegevoegd
- [x] Witregels gecheckt
- [x] Bronnenlijst toegevoegd (indien nodig)
- [x] Content-branch gepulled in de feature branch
- [x] Benodigde verwijzingen toegevoegd