### PR TITLE
Correctie Oefeningen List.md opdracht 9

### DIFF
--- a/build/4. Csharp/Datastructuren/List/2. Oefeningen List.md
+++ b/build/4. Csharp/Datastructuren/List/2. Oefeningen List.md
@@ -391,7 +391,7 @@ List<string> groceries = new List<string> {"Boter","Melk","Appels","Pasta","Koff
 
 int itemCount = groceries.________;
 
-Console.WriteLine($"ItemCount is: {itemcount}");
+Console.WriteLine($"ItemCount is: {itemCount}");
 ``` 
 
 > [!info]- Mogelijke uitwerking
@@ -400,7 +400,8 @@ Console.WriteLine($"ItemCount is: {itemcount}");
 > 
 > List<string> groceries = new List<string> { "Boter", "Melk", "Appels", "Pasta", "Koffie", "Eieren" };
 > 
-> int itemcount = groceries.Count;
+> int itemCount = groceries.Count;
 > 
-> Console.WriteLine($"ItemCount is: {itemcount}");
+> Console.WriteLine($"ItemCount is: {itemCount}");
+
 > ```


### PR DESCRIPTION
## Beschrijving
In de voorbeeldcode bij opdracht 9 staat een variabele 'itemCount', waar 'Count' met een hoofdletter is geschreven. In de WriteLine wordt deze variabele aangeroepen met een kleine letter c, wat een foutmelding oplevert. In de uitwerking staat de variabele ook met een kleine letter c geschreven. Deze wijziging trekt 1 lijn in deze variabele.

## Checklist
- [x] Content voldoet aan gestelde eisen uit `Kwaliteitseisen Onderwijs Aanbod.docx`
- [x] Spellingscheck gedaan
- [x] Content geschreven volgens de gekoppelde 4C/ID componenten templates
- [x] De naam van het onderwerp in de tekst is bold
- [x] MD koppen hebben geen bold teksten
- [x] Juiste format voor image/figuur naamgevingen
- [x] Figuur onderschriften toegevoegd waar nodig
- [x] Taxonomie codes toegevoegd
- [x] Witregels gecheckt
- [x] Bronnenlijst toegevoegd (indien nodig)
- [x] Content-branch gepulled in de feature branch
- [x] Benodigde verwijzingen toegevoegd
